### PR TITLE
Fix example code to include `.git`

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ const http = require('isomorphic-git/http/node')
 const fs = require('fs')
 
 const dir = path.join(process.cwd(), 'test-clone')
-git.clone({ fs, http, dir, url: 'https://github.com/isomorphic-git/lightning-fs' }).then(console.log)
+git.clone({ fs, http, dir, url: 'https://github.com/isomorphic-git/lightning-fs.git' }).then(console.log)
 ```
 
 If you're using `isomorphic-git` in the browser, you'll need something that emulates the `fs` API.
@@ -79,7 +79,7 @@ import http from 'https://unpkg.com/isomorphic-git@beta/http/web/index.js'
 const fs = new LightningFS('fs')
 
 const dir = '/test-clone'
-git.clone({ fs, http, dir, url: 'https://github.com/isomorphic-git/lightning-fs', corsProxy: 'https://cors.isomorphic-git.org' }).then(console.log)
+git.clone({ fs, http, dir, url: 'https://github.com/isomorphic-git/lightning-fs.git', corsProxy: 'https://cors.isomorphic-git.org' }).then(console.log)
 </script>
 ```
 


### PR DESCRIPTION
Example code does not run unless `.git` is present on github urls

<!-- Oh wow! Thanks for opening a pull request! 😁 🎉 -->
<!-- You are very welcome here and any contribution is appreciated. 👍 -->
<!-- Choose one of the checklists if it applies to you and delete the rest. -->

## I'm fixing a bug or typo

- [ ] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [ ] squash merge the PR with commit message "fix: [Description of fix]"

## I'm adding a parameter to an existing command X:

- [ ] add parameter to the function in `src/api/X.js` (and `src/commands/X.js` if necessary)
- [ ] document the parameter in the JSDoc comment above the function
- [ ] add a test case in `__tests__/test-X.js` if possible
- [ ] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [ ] squash merge the PR with commit message "feat(X): Added 'bar' parameter"

## I'm adding a new command:

- [ ] add as a new file in `src/api` (and `src/commands` if necessary)
- [ ] add command to `src/index.js`
- [ ] update `__tests__/__snapshots__/test-exports.js.snap`
- [ ] create a test in `src/__tests__`
- [ ] document the command with a JSDoc comment
- [ ] add page to the Docs Sidebar `website/sidebars.json`
- [ ] add page to the v1 Docs Sidebar `website/versioned_sidebars/version-1.x-sidebars.json`
- [ ] if this is your first time contributing, run `npm run add-contributor` and follow the prompts to add yourself to the README
- [ ] squash merge the PR with commit message "feat: Added 'X' command"
